### PR TITLE
(filters/webhook) display webhook avatar as thumbnail if possible

### DIFF
--- a/src/bot/exts/filters/webhook_remover.py
+++ b/src/bot/exts/filters/webhook_remover.py
@@ -81,7 +81,7 @@ class WebhookRemover(Cog):
         )
 
         # Display Bot icon as thumbnail
-        if webhook_metadata["avatar"] == null:
+        if webhook_metadata["avatar"] is None:
             thumb = f"https://cdn.discordapp.com/avatars/{webhook_metadata['id']}/{webhook_metadata['avatar']}.webp"
         else:
             thumb = message.author.display_avatar.url

--- a/src/bot/exts/filters/webhook_remover.py
+++ b/src/bot/exts/filters/webhook_remover.py
@@ -79,13 +79,13 @@ class WebhookRemover(Cog):
             thumbnail=message.author.display_avatar.url,
             channel_id=Channels.mod_alerts,
         )
-        
+
         # Display Bot icon as thumbnail
         if webhook_metadata["avatar"] == null:
             thumb = f"https://cdn.discordapp.com/avatars/{webhook_metadata['id']}/{webhook_metadata['avatar']}.webp"
         else:
             thumb = message.author.display_avatar.url
-        
+
         # Log to SOC
         text = (
             f"{format_user(message.author)} posted a Discord webhook URL to {message.channel.mention}. {delete_state} "

--- a/src/bot/exts/filters/webhook_remover.py
+++ b/src/bot/exts/filters/webhook_remover.py
@@ -79,7 +79,13 @@ class WebhookRemover(Cog):
             thumbnail=message.author.display_avatar.url,
             channel_id=Channels.mod_alerts,
         )
-
+        
+        # Display Bot icon as thumbnail
+        if webhook_metadata["avatar"] == null:
+            thumb = f"https://cdn.discordapp.com/avatars/{webhook_metadata['id']}/{webhook_metadata['avatar']}.webp"
+        else:
+            thumb = message.author.display_avatar.url
+        
         # Log to SOC
         text = (
             f"{format_user(message.author)} posted a Discord webhook URL to {message.channel.mention}. {delete_state} "
@@ -91,7 +97,7 @@ class WebhookRemover(Cog):
             colour=Colour(Colours.soft_red),
             title="Discord webhook URL removed!",
             text=text,
-            thumbnail=message.author.display_avatar.url,
+            thumbnail=thumb,
             channel_id=Channels.soc_alerts,
         )
 


### PR DESCRIPTION
Display the webhook avatar instead of the user who sent the webhook. May implement image hashing functions for further fingerprinting.