### PR TITLE
Update webhook_remover.py

### DIFF
--- a/src/bot/exts/filters/webhook_remover.py
+++ b/src/bot/exts/filters/webhook_remover.py
@@ -14,7 +14,7 @@ from bot.exts.core.log import Log
 from bot.utils.messages import format_user
 
 WEBHOOK_URL_RE = re.compile(
-    r"(https?:\/\/(ptb\.|canary\.)?discord(app)?\.com\/api(\/v\d{1,2})?\/webhooks\/(\d{17,21})\/)([\w-]{68})",
+    r"(https?:\/\/(www\.|ptb\.|canary\.)?discord(app)?\.com\/api(\/v\d{1,2})?\/webhooks\/(\d{17,21})\/)([\w-]{68})",
     re.IGNORECASE,
 )
 


### PR DESCRIPTION
Apparently `www` is a valid subdomain for discord webhooks (??) `www.discord.com` redirects to `discord.com`