### PR TITLE
Constrain deps, build container on PR

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,4 +16,4 @@ jobs:
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v3
         with:
-          config-file: darbiadev/.github/.github/dependency-review-config.yaml@570079218747889f03eafe6ef14f855635ecbdee
+          config-file: darbiadev/.github/.github/dependency-review-config.yaml@307c66955ab6d811fbeb45f8e49dfe5d51e5d285

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -6,6 +6,7 @@ on:
       - main
     tags:
       - v*
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -17,4 +17,4 @@ permissions:
 
 jobs:
   build-push:
-    uses: darbiadev/.github/.github/workflows/docker-build-push.yaml@307c66955ab6d811fbeb45f8e49dfe5d51e5d285
+    uses: darbiadev/.github/.github/workflows/docker-build-push.yaml@4cf78eb62eae87baacb57a9655070fd6dfac6f7f

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -16,4 +16,4 @@ permissions:
 
 jobs:
   build-push:
-    uses: darbiadev/.github/.github/workflows/docker-build-push.yaml@570079218747889f03eafe6ef14f855635ecbdee
+    uses: darbiadev/.github/.github/workflows/docker-build-push.yaml@307c66955ab6d811fbeb45f8e49dfe5d51e5d285

--- a/.github/workflows/github-pages-python-sphinx.yaml
+++ b/.github/workflows/github-pages-python-sphinx.yaml
@@ -13,4 +13,4 @@ permissions:
 
 jobs:
   docs:
-    uses: darbiadev/.github/.github/workflows/github-pages-python-sphinx.yaml@570079218747889f03eafe6ef14f855635ecbdee
+    uses: darbiadev/.github/.github/workflows/github-pages-python-sphinx.yaml@307c66955ab6d811fbeb45f8e49dfe5d51e5d285

--- a/.github/workflows/precommit-autoupdate.yaml
+++ b/.github/workflows/precommit-autoupdate.yaml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   pre-commit-autoupdate:
-    uses: darbiadev/.github/.github/workflows/generic-precommit-autoupdate.yaml@570079218747889f03eafe6ef14f855635ecbdee
+    uses: darbiadev/.github/.github/workflows/generic-precommit-autoupdate.yaml@307c66955ab6d811fbeb45f8e49dfe5d51e5d285

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   pre-commit:
-    uses: darbiadev/.github/.github/workflows/generic-precommit.yaml@570079218747889f03eafe6ef14f855635ecbdee
+    uses: darbiadev/.github/.github/workflows/generic-precommit.yaml@307c66955ab6d811fbeb45f8e49dfe5d51e5d285
 
   lint:
     needs: pre-commit
-    uses: darbiadev/.github/.github/workflows/python-lint.yaml@570079218747889f03eafe6ef14f855635ecbdee
+    uses: darbiadev/.github/.github/workflows/python-lint.yaml@307c66955ab6d811fbeb45f8e49dfe5d51e5d285
 
   test:
     needs: lint
@@ -21,7 +21,7 @@ jobs:
         os: [ ubuntu-latest ]
         python-version: [ "3.10", "3.11" ]
 
-    uses: darbiadev/.github/.github/workflows/python-test.yaml@570079218747889f03eafe6ef14f855635ecbdee
+    uses: darbiadev/.github/.github/workflows/python-test.yaml@307c66955ab6d811fbeb45f8e49dfe5d51e5d285
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ profile = "black"
 [tool.pylint.format]
 max-line-length = 120
 
+[tool.ruff]
+line-length = 120
+
 [tool.pylint.messages_control]
 disable = "W1203,R0903,R0911"
 # justifications:

--- a/requirements/requirements-dev.in
+++ b/requirements/requirements-dev.in
@@ -2,6 +2,9 @@
 # --index-url=http://pypi.example.com/simple
 # --no-cache-dir
 
+# Constrain versions installed to be compatible with core dependencies
+--constraint requirements.pip
+
 black
 isort
 pylint

--- a/requirements/requirements-dev.in
+++ b/requirements/requirements-dev.in
@@ -8,3 +8,4 @@
 black
 isort
 pylint
+ruff

--- a/requirements/requirements-dev.pip
+++ b/requirements/requirements-dev.pip
@@ -10,10 +10,6 @@ black==23.3.0
     # via -r requirements/requirements-dev.in
 click==8.1.3
     # via black
-colorama==0.4.6
-    # via
-    #   click
-    #   pylint
 dill==0.3.6
     # via pylint
 isort==5.12.0

--- a/requirements/requirements-dev.pip
+++ b/requirements/requirements-dev.pip
@@ -32,6 +32,8 @@ platformdirs==3.5.0
     #   pylint
 pylint==2.17.4
     # via -r requirements/requirements-dev.in
+ruff==0.0.269
+    # via -r requirements/requirements-dev.in
 tomlkit==0.11.8
     # via pylint
 wrapt==1.15.0

--- a/requirements/requirements-docs.in
+++ b/requirements/requirements-docs.in
@@ -2,9 +2,11 @@
 # --index-url=http://pypi.example.com/simple
 # --no-cache-dir
 
+# Constrain versions installed to be compatible with core dependencies
+--constraint requirements.pip
+
 sphinx
 furo
 sphinx-autoapi
 toml
 releases
-urllib3==1.26.15

--- a/requirements/requirements-docs.pip
+++ b/requirements/requirements-docs.pip
@@ -13,17 +13,21 @@ babel==2.12.1
 beautifulsoup4==4.12.2
     # via furo
 certifi==2023.5.7
-    # via requests
+    # via
+    #   -c requirements/requirements.pip
+    #   requests
 charset-normalizer==3.1.0
-    # via requests
-colorama==0.4.6
-    # via sphinx
+    # via
+    #   -c requirements/requirements.pip
+    #   requests
 docutils==0.19
     # via sphinx
 furo==2023.3.27
     # via -r requirements/requirements-docs.in
 idna==3.4
-    # via requests
+    # via
+    #   -c requirements/requirements.pip
+    #   requests
 imagesize==1.4.1
     # via sphinx
 jinja2==3.1.2
@@ -81,7 +85,7 @@ unidecode==1.3.6
     # via sphinx-autoapi
 urllib3==1.26.15
     # via
-    #   -r requirements/requirements-docs.in
+    #   -c requirements/requirements.pip
     #   requests
 wrapt==1.15.0
     # via astroid

--- a/requirements/requirements-tests.in
+++ b/requirements/requirements-tests.in
@@ -2,4 +2,6 @@
 # --index-url=http://pypi.example.com/simple
 # --no-cache-dir
 
+# Constrain versions installed to be compatible with core dependencies
+--constraint requirements.pip
 pytest

--- a/requirements/requirements-tests.pip
+++ b/requirements/requirements-tests.pip
@@ -4,8 +4,6 @@
 #
 #    pip-compile --output-file=requirements/requirements-tests.pip --resolver=backtracking requirements/requirements-tests.in
 #
-colorama==0.4.6
-    # via pytest
 iniconfig==2.0.0
     # via pytest
 packaging==23.1

--- a/requirements/requirements.pip
+++ b/requirements/requirements.pip
@@ -42,8 +42,6 @@ psycopg-binary==3.1.9
     # via psycopg
 pydantic==1.10.7
     # via -r requirements/requirements.in
-pyreadline3==3.4.1
-    # via humanfriendly
 python-dotenv==1.0.0
     # via -r requirements/requirements.in
 rapidfuzz==3.0.0
@@ -57,8 +55,6 @@ typing-extensions==4.5.0
     #   psycopg
     #   pydantic
     #   sqlalchemy
-tzdata==2023.3
-    # via psycopg
 urllib3==1.26.15
     # via sentry-sdk
 yarl==1.9.2


### PR DESCRIPTION
Add the main `requirements.pip` as a constraint file to the optional dependency files to force optional dependencies to maintain compatibility with the main dependencies.

Build but don't push the container on PR, adding an extra sanity check. 