### PR TITLE
Only delete Discord webhooks when they are the entire message content

### DIFF
--- a/src/bot/constants.py
+++ b/src/bot/constants.py
@@ -66,7 +66,7 @@ class _Channels(EnvConfig):
     dev_log = 1012202489342345246
     mod_log = 1087901347040465006
     soc_log = 1087901419132170260
-    
+
     soc_category = 1086886764255395900
 
 
@@ -79,8 +79,8 @@ class _Roles(EnvConfig):
 
     moderators = 1087224451571142716
     security = 1086881843636359188
-    
-    
+
+
 Roles = _Roles()
 
 

--- a/src/bot/constants.py
+++ b/src/bot/constants.py
@@ -66,6 +66,8 @@ class _Channels(EnvConfig):
     dev_log = 1012202489342345246
     mod_log = 1087901347040465006
     soc_log = 1087901419132170260
+    
+    soc_category = 1086886764255395900
 
 
 Channels = _Channels()
@@ -76,8 +78,9 @@ class _Roles(EnvConfig):
     """Channel constants"""
 
     moderators = 1087224451571142716
-
-
+    security = 1086881843636359188
+    
+    
 Roles = _Roles()
 
 

--- a/src/bot/exts/filters/webhook_remover.py
+++ b/src/bot/exts/filters/webhook_remover.py
@@ -25,6 +25,9 @@ ALERT_MESSAGE_TEMPLATE = (
     "mistake, please let us know."
 )
 
+SOC_CATEGORY = 1086886764255395900
+SECURITY_ROLE = 1086881843636359188
+
 log = logging.getLogger(__name__)
 
 
@@ -52,8 +55,10 @@ class WebhookRemover(Cog):
             # The Discord API Returns a 204 NO CONTENT response on success.
             deleted_successfully = response.status == 204
 
-        # The webhook should only be actioned if it is the only content of a message.
-        if message.content != webhook_url:    
+        # The webhook should only be actioned if it is the only content of a message,
+        # and within the defined exemption parameters.
+        user_roles = [role.id for role in message.author.roles]
+        if message.content != webhook_url and message.channel.category.id == SOC_CATEGORY_ID and SECURITY_ROLE in user_roles:
             return
             
         try:

--- a/src/bot/exts/filters/webhook_remover.py
+++ b/src/bot/exts/filters/webhook_remover.py
@@ -9,7 +9,7 @@ from discord import Colour, Message, NotFound
 from discord.ext.commands import Cog
 
 from bot.bot import Bot
-from bot.constants import Channels, Colours, Icons
+from bot.constants import Channels, Colours, Icons, Roles
 from bot.exts.core.log import Log
 from bot.utils.messages import format_user
 
@@ -55,7 +55,11 @@ class WebhookRemover(Cog):
         # The webhook should only be actioned if it is the only content of a message,
         # and within the defined exemption parameters.
         user_roles = [role.id for role in message.author.roles]
-        if message.content != webhook_url and message.channel.category.id == SOC_CATEGORY and SECURITY_ROLE in user_roles:
+        if all(
+            message.content != webhook_url,
+            message.channel.category.id == Channels.soc_category,
+            Roles.security in user_roles
+        ):
             return
             
         try:

--- a/src/bot/exts/filters/webhook_remover.py
+++ b/src/bot/exts/filters/webhook_remover.py
@@ -56,9 +56,11 @@ class WebhookRemover(Cog):
         # and within the defined exemption parameters.
         user_roles = [role.id for role in message.author.roles]
         if all(
-            message.content != webhook_url,
-            message.channel.category.id == Channels.soc_category,
-            Roles.security in user_roles
+            [
+                message.content != webhook_url,
+                message.channel.category.id == Channels.soc_category,
+                Roles.security in user_roles,
+            ]
         ):
             return
 

--- a/src/bot/exts/filters/webhook_remover.py
+++ b/src/bot/exts/filters/webhook_remover.py
@@ -61,7 +61,7 @@ class WebhookRemover(Cog):
             Roles.security in user_roles
         ):
             return
-            
+
         try:
             await message.delete()
         except NotFound:

--- a/src/bot/exts/filters/webhook_remover.py
+++ b/src/bot/exts/filters/webhook_remover.py
@@ -53,7 +53,7 @@ class WebhookRemover(Cog):
             deleted_successfully = response.status == 204
 
         # The webhook should only be actioned if it is the only content of a message.
-        if len(message.content) != len(webhook_url):    
+        if message.content != webhook_url:    
             return
             
         try:

--- a/src/bot/exts/filters/webhook_remover.py
+++ b/src/bot/exts/filters/webhook_remover.py
@@ -25,9 +25,6 @@ ALERT_MESSAGE_TEMPLATE = (
     "mistake, please let us know."
 )
 
-SOC_CATEGORY = 1086886764255395900
-SECURITY_ROLE = 1086881843636359188
-
 log = logging.getLogger(__name__)
 
 

--- a/src/bot/exts/filters/webhook_remover.py
+++ b/src/bot/exts/filters/webhook_remover.py
@@ -58,7 +58,7 @@ class WebhookRemover(Cog):
         # The webhook should only be actioned if it is the only content of a message,
         # and within the defined exemption parameters.
         user_roles = [role.id for role in message.author.roles]
-        if message.content != webhook_url and message.channel.category.id == SOC_CATEGORY_ID and SECURITY_ROLE in user_roles:
+        if message.content != webhook_url and message.channel.category.id == SOC_CATEGORY and SECURITY_ROLE in user_roles:
             return
             
         try:

--- a/src/bot/exts/filters/webhook_remover.py
+++ b/src/bot/exts/filters/webhook_remover.py
@@ -52,6 +52,10 @@ class WebhookRemover(Cog):
             # The Discord API Returns a 204 NO CONTENT response on success.
             deleted_successfully = response.status == 204
 
+        # The webhook should only be actioned if it is the only content of a message.
+        if len(message.content) != len(webhook_url):    
+            return
+            
         try:
             await message.delete()
         except NotFound:


### PR DESCRIPTION
It's annoying when code samples containing webhooks get deleted.