### PR TITLE
Have Dependabot group dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,13 +4,25 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      ci-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      docker-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Having many many PRs is annoying.